### PR TITLE
Fix: Correct Flutter Teams API snippets

### DIFF
--- a/snippets/flutter/teams.code-snippets
+++ b/snippets/flutter/teams.code-snippets
@@ -2,7 +2,7 @@
   "Initialize Team": {
     "scope": "dart",
     "prefix": ["team"],
-    "body": ["final Team team = Team(client);"],
+    "body": ["final Teams teams = Teams(client);"],
     "description": "Create a Team object and initialize it."
   },
 
@@ -10,7 +10,7 @@
     "scope": "dart",
     "prefix": ["createTeam", "crTeam"],
     "body": [
-      "final ${1:response} = await team.create(teamId: \"${2:teamId}\" ,name: \"${3:name}\");"
+      "final ${1:response} = await teams.create(teamId: \"${2:teamId}\" ,name: \"${3:name}\");"
     ],
     "description": "Create a new Team."
   },
@@ -18,14 +18,14 @@
   "List Teams": {
     "scope": "dart",
     "prefix": ["listTeams", "listTeams"],
-    "body": ["final ${1:response} = await team.list();"],
+    "body": ["final ${1:response} = await teams.list();"],
     "description": "Get a list of all the user teams. You can use the query params to filter your results. On admin mode, this endpoint will return a list of all of the project's teams."
   },
 
   "Get Team": {
     "scope": "dart",
     "prefix": "getTeam",
-    "body": ["final ${1:response} = await team.get(teamId: \"${2:teamId}\");"],
+    "body": ["final ${1:response} = await teams.get(teamId: \"${2:teamId}\");"],
     "description": "Get a team by its unique ID."
   },
 
@@ -33,7 +33,7 @@
     "scope": "dart",
     "prefix": ["updateTeam", "upTeam"],
     "body": [
-      "final ${1:response} = await team.update(teamId: \"${2:teamId}\", name: \"${3:name}\");"
+      "final ${1:response} = await teams.update(teamId: \"${2:teamId}\", name: \"${3:name}\");"
     ],
     "description": "Update a team by its unique ID."
   },
@@ -41,7 +41,7 @@
   "Delete Team": {
     "scope": "dart",
     "prefix": ["deleteTeam", "delTeam"],
-    "body": ["await team.delete(teamId: \"${2:teamId}\");"],
+    "body": ["await teams.delete(teamId: \"${2:teamId}\");"],
     "description": "Delete a team by its unique ID."
   },
 
@@ -49,7 +49,7 @@
     "scope": "dart",
     "prefix": ["createTeamMembership", "crTeamMembership"],
     "body": [
-      "final ${1:response} = await team.createMembership(teamId: \"${2:teamId}\", email: \"${3:email}\",roles: [$4], url: \"${5:url}\");"
+      "final ${1:response} = await teams.createMembership(teamId: \"${2:teamId}\", email: \"${3:email}\",roles: [$4], url: \"${5:url}\");"
     ],
     "description": "Create a new Team Membership."
   },
@@ -58,7 +58,7 @@
     "scope": "dart",
     "prefix": ["getTeamMembership", "gtmembership"],
     "body": [
-      "final ${1:response} = await team.getMembership(teamId: \"${2:teamId}\");"
+      "final ${1:response} = await teams.getMembership(teamId: \"${2:teamId}\");"
     ],
     "description": "Get a team membership by its unique ID."
   },
@@ -67,7 +67,7 @@
     "scope": "dart",
     "prefix": ["updateTeamMembershiproles"],
     "body": [
-      "final ${1:response} = await team.updateMembershipRoles(teamId: \"${2:teamId}\", membershipId: \"${3:membershipId}\",roles: [$4]);"
+      "final ${1:response} = await teams.updateMembershipRoles(teamId: \"${2:teamId}\", membershipId: \"${3:membershipId}\",roles: [$4]);"
     ],
     "description": "Modify the roles of a team member. Only team members with the owner role have access to this endpoint."
   },
@@ -76,7 +76,7 @@
     "scope": "dart",
     "prefix": ["updateTeamMembershipstatus"],
     "body": [
-      "final ${1:response} = await team.updateMembershipStatus(teamId: \"${2:teamId}\", membershipId: \"${3:membershipId}\", userId: \"${4:userId}\", secret: \"${5:secret}\");"
+      "final ${1:response} = await teams.updateMembershipStatus(teamId: \"${2:teamId}\", membershipId: \"${3:membershipId}\", userId: \"${4:userId}\", secret: \"${5:secret}\");"
     ],
     "description": "Use this endpoint to allow a user to accept an invitation to join a team after being redirected back to your app from the invitation email received by the user."
   },
@@ -85,7 +85,7 @@
     "scope": "dart",
     "prefix": ["deleteTeamMembership", "deleteTeamMembership"],
     "body": [
-      "await team.deleteMembership(teamId: \"${2:teamId}\", membershipId: \"${3:membershipId}\");"
+      "await teams.deleteMembership(teamId: \"${2:teamId}\", membershipId: \"${3:membershipId}\");"
     ],
     "description": "This endpoint allows a user to leave a team or for a team owner to delete the membership of any other team member. You can also use this endpoint to delete a user membership even if it is not accepted."
   }


### PR DESCRIPTION
## Description  
Correct the **Initialize Team** snippet and make the `teams` object name consistent based on that across the rest of the snippets.

The class for `Teams` API is `Teams()` and not `Team()` as per the docs. I've accordingly changed the object name from `team` to `teams` across the rest of the snippets because the object refers to the Teams API and not an individual team.

## Testing  
Followed the steps to test in the Contributing Guide

## Checklist  
- [x] Followed the [contribution guidelines](https://github.com/2002Bishwajeet/awesome-appwrite-snippets/blob/master/CONTRIBUTING.md)  
- [x] The code is commented properly to give appropriate context.
